### PR TITLE
Add indexes on Thing:authority and Thing:authorityValue

### DIFF
--- a/concepts/concepts_service.go
+++ b/concepts/concepts_service.go
@@ -38,7 +38,8 @@ func (s Service) Initialise() error {
 	}
 
 	err = s.conn.EnsureIndexes(map[string]string{
-		"Thing": "authorityValue",
+		"Thing":   "authorityValue",
+		"Concept": "authorityValue",
 	})
 	if err != nil {
 		log.WithError(err).Error("Could not run db index")

--- a/concepts/concepts_service.go
+++ b/concepts/concepts_service.go
@@ -38,14 +38,6 @@ func (s Service) Initialise() error {
 	}
 
 	err = s.conn.EnsureIndexes(map[string]string{
-		"Thing": "authority",
-	})
-	if err != nil {
-		log.WithError(err).Error("Could not run db index")
-		return err
-	}
-
-	err = s.conn.EnsureIndexes(map[string]string{
 		"Thing": "authorityValue",
 	})
 	if err != nil {

--- a/concepts/concepts_service.go
+++ b/concepts/concepts_service.go
@@ -9,10 +9,11 @@ import (
 	"time"
 
 	"errors"
+	"strconv"
+
 	"github.com/Financial-Times/neo-utils-go/neoutils"
 	log "github.com/Sirupsen/logrus"
 	"github.com/jmcvetta/neoism"
-	"strconv"
 )
 
 //Service - CypherDriver - CypherDriver
@@ -31,7 +32,22 @@ func (s Service) Initialise() error {
 		"Identifier": "value",
 		"Thing":      "prefUUID",
 	})
+	if err != nil {
+		log.WithError(err).Error("Could not run db index")
+		return err
+	}
 
+	err = s.conn.EnsureIndexes(map[string]string{
+		"Thing": "authority",
+	})
+	if err != nil {
+		log.WithError(err).Error("Could not run db index")
+		return err
+	}
+
+	err = s.conn.EnsureIndexes(map[string]string{
+		"Thing": "authorityValue",
+	})
 	if err != nil {
 		log.WithError(err).Error("Could not run db index")
 		return err


### PR DESCRIPTION
The EnsureIndexes can't put more than one index on each label (it's a map, so no duplicate keys), so we have to repeat the block to allow it to work.  Ideally neoutils can be updated to deal with multiple keys but this workaround will suffice for now.