### PR TITLE
Fix - Adding concordance when one side didn't exist broke the node delete

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-LOG_LEVEL=debug
-NEO4J_TEST_URL=http://localhost:7474/db/data
-NEO_URL=http://localhost:7474/db/data

--- a/concepts/concepts_service.go
+++ b/concepts/concepts_service.go
@@ -537,7 +537,7 @@ func (s ConceptService) handleTransferConcordance(updatedSourceIds []string, pre
 func deleteLonePrefUuid(prefUUID string) *neoism.CypherQuery {
 	logger.WithField("UUID", prefUUID).Debug("Deleting orphaned prefUUID node")
 	equivQuery := &neoism.CypherQuery{
-		Statement: `MATCH (t:Thing {prefUUID:{id}}) DELETE t`,
+		Statement: `MATCH (t:Thing {prefUUID:{id}}) DETACH DELETE t`,
 		Parameters: map[string]interface{}{
 			"id": prefUUID,
 		},

--- a/concepts/concepts_service.go
+++ b/concepts/concepts_service.go
@@ -399,7 +399,7 @@ func (s ConceptService) Write(thing interface{}, transID string) (interface{}, e
 
 	logger.WithTransactionID(transID).WithUUID(aggregatedConceptToWrite.PrefUUID).Debug("Executing " + strconv.Itoa(len(queryBatch)) + " queries")
 	for _, query := range queryBatch {
-		logger.WithTransactionID(transID).WithUUID(aggregatedConceptToWrite.PrefUUID).Debug(fmt.Sprintf("Query: %s", query))
+		logger.WithTransactionID(transID).WithUUID(aggregatedConceptToWrite.PrefUUID).Debug(fmt.Sprintf("Query: %v", query))
 	}
 
 	if err = s.conn.CypherBatch(queryBatch); err != nil {

--- a/concepts/concepts_service.go
+++ b/concepts/concepts_service.go
@@ -34,7 +34,7 @@ func NewConceptService(cypherRunner neoutils.NeoConnection) ConceptService {
 }
 
 //Initialise - Would this be better as an extension in Neo4j? i.e. that any Thing has this constraint added on creation
-func (s ConceptService) Initialise() error {
+func (s *ConceptService) Initialise() error {
 	err := s.conn.EnsureIndexes(map[string]string{
 		"Identifier": "value",
 	})
@@ -118,7 +118,7 @@ type equivalenceResult struct {
 }
 
 //Read - read service
-func (s ConceptService) Read(uuid string, transID string) (interface{}, bool, error) {
+func (s *ConceptService) Read(uuid string, transID string) (interface{}, bool, error) {
 	results := []neoAggregatedConcept{}
 
 	query := &neoism.CypherQuery{
@@ -290,7 +290,7 @@ func (s ConceptService) Read(uuid string, transID string) (interface{}, bool, er
 	return aggregatedConcept, true, nil
 }
 
-func (s ConceptService) Write(thing interface{}, transID string) (interface{}, error) {
+func (s *ConceptService) Write(thing interface{}, transID string) (interface{}, error) {
 	// Read the aggregated concept - We need read the entire model first. This is because if we unconcord a TME concept
 	// then we need to add prefUUID to the lone node if it has been removed from the concordance listed against a Smartlogic concept
 	uuidsToUpdate := UpdatedConcepts{}
@@ -468,7 +468,7 @@ func filterIdsThatAreUniqueToFirstList(firstListIds []string, secondListIds []st
 }
 
 //Handle new source nodes that have been added to current concordance
-func (s ConceptService) handleTransferConcordance(updatedSourceIds []string, prefUUID string, transID string) ([]*neoism.CypherQuery, error) {
+func (s *ConceptService) handleTransferConcordance(updatedSourceIds []string, prefUUID string, transID string) ([]*neoism.CypherQuery, error) {
 	result := []equivalenceResult{}
 	deleteLonePrefUuidQueries := []*neoism.CypherQuery{}
 
@@ -546,7 +546,7 @@ func deleteLonePrefUuid(prefUUID string) *neoism.CypherQuery {
 }
 
 //Clear down current concept node
-func (s ConceptService) clearDownExistingNodes(ac AggregatedConcept) []*neoism.CypherQuery {
+func (s *ConceptService) clearDownExistingNodes(ac AggregatedConcept) []*neoism.CypherQuery {
 	acUUID := ac.PrefUUID
 	sourceUuids := getSourceIds(ac.SourceRepresentations)
 
@@ -756,7 +756,7 @@ func addRelationship(conceptID string, relationshipIDs []string, relationshipTyp
 }
 
 //Create canonical node for any concepts that were removed from a concordance and thus would become lone
-func (s ConceptService) writeCanonicalNodeForUnconcordedConcepts(concept Concept) *neoism.CypherQuery {
+func (s *ConceptService) writeCanonicalNodeForUnconcordedConcepts(concept Concept) *neoism.CypherQuery {
 	allProps := setProps(concept, concept.UUID, false)
 	logger.WithField("UUID", concept.UUID).Debug("Creating prefUUID node for unconcorded concept")
 	createCanonicalNodeQuery := &neoism.CypherQuery{
@@ -884,14 +884,14 @@ func createNewIdentifierQuery(uuid string, identifierLabel string, identifierVal
 }
 
 //DecodeJSON - decode json
-func (s ConceptService) DecodeJSON(dec *json.Decoder) (interface{}, string, error) {
+func (s *ConceptService) DecodeJSON(dec *json.Decoder) (interface{}, string, error) {
 	sub := AggregatedConcept{}
 	err := dec.Decode(&sub)
 	return sub, sub.PrefUUID, err
 }
 
 //Check - checker
-func (s ConceptService) Check() error {
+func (s *ConceptService) Check() error {
 	return neoutils.Check(s.conn)
 }
 

--- a/concepts/concepts_service_test.go
+++ b/concepts/concepts_service_test.go
@@ -1061,9 +1061,9 @@ func getIdentifierValue(t *testing.T, uuidPropertyName string, uuid string, labe
 }
 
 func verifyAggregateHashIsCorrect(t *testing.T, concept AggregatedConcept, testName string) {
-	results := []struct {
+	var results []struct {
 		Hash string `json:"a.aggregateHash"`
-	}{}
+	}
 
 	query := &neoism.CypherQuery{
 		Statement: `
@@ -1076,7 +1076,7 @@ func verifyAggregateHashIsCorrect(t *testing.T, concept AggregatedConcept, testN
 	}
 	err := db.CypherBatch([]*neoism.CypherQuery{query})
 	assert.NoError(t, err, fmt.Sprintf("Error while retrieving concept hash"))
-	fmt.Sprintf("Results are %v\n", results)
+	fmt.Printf("Results are %v\n", results)
 
 	conceptHash, _ := hashstructure.Hash(concept, nil)
 	hashAsString := strconv.FormatUint(conceptHash, 10)

--- a/concepts/concepts_service_test.go
+++ b/concepts/concepts_service_test.go
@@ -1038,9 +1038,9 @@ func deleteConcordedNodes(t *testing.T, uuids ...string) {
 }
 
 func getIdentifierValue(t *testing.T, uuidPropertyName string, uuid string, label string) string {
-	results := []struct {
+	var results []struct {
 		Value string `json:"i.value"`
-	}{}
+	}
 
 	query := &neoism.CypherQuery{
 		Statement: fmt.Sprintf(`

--- a/concepts/handlers.go
+++ b/concepts/handlers.go
@@ -67,12 +67,13 @@ func (h *ConceptsHandler) PutConcept(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	enc := json.NewEncoder(w)
-	if err = enc.Encode(updatedIds); err != nil {
+	updateIDsBody, err := json.Marshal(updatedIds)
+	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusInternalServerError)
 		return
 	} else {
 		w.WriteHeader(http.StatusOK)
+		w.Write(updateIDsBody)
 		return
 	}
 }

--- a/concepts/handlers_test.go
+++ b/concepts/handlers_test.go
@@ -26,7 +26,7 @@ func TestPutHandler(t *testing.T) {
 		contentType string // Contents of the Content-Type header
 		body        string
 	}{
-		{"Success", newRequest("PUT", fmt.Sprintf("/dummies/%s", knownUUID)), mockConceptService{uuid: knownUUID}, http.StatusOK, "", "{\"updatedIDs\":null}\n"},
+		{"Success", newRequest("PUT", fmt.Sprintf("/dummies/%s", knownUUID)), mockConceptService{uuid: knownUUID}, http.StatusOK, "", "{\"updatedIDs\":null}"},
 		{"ParseError", newRequest("PUT", fmt.Sprintf("/dummies/%s", knownUUID)), mockConceptService{uuid: knownUUID, failParse: true}, http.StatusBadRequest, "", errorMessage("TEST failing to DECODE")},
 		{"UUIDMisMatch", newRequest("PUT", fmt.Sprintf("/dummies/%s", "99999")), mockConceptService{uuid: knownUUID}, http.StatusBadRequest, "", errorMessage("Uuids from payload and request, respectively, do not match: '12345' '99999'")},
 		{"WriteFailed", newRequest("PUT", fmt.Sprintf("/dummies/%s", knownUUID)), mockConceptService{uuid: knownUUID, failWrite: true}, http.StatusServiceUnavailable, "", errorMessage("TEST failing to WRITE")},

--- a/concepts/handlers_test.go
+++ b/concepts/handlers_test.go
@@ -26,11 +26,11 @@ func TestPutHandler(t *testing.T) {
 		contentType string // Contents of the Content-Type header
 		body        string
 	}{
-		{"Success", newRequest("PUT", fmt.Sprintf("/dummies/%s", knownUUID)), mockConceptService{uuid: knownUUID}, http.StatusOK, "", "{\"updatedIDs\":null}"},
-		{"ParseError", newRequest("PUT", fmt.Sprintf("/dummies/%s", knownUUID)), mockConceptService{uuid: knownUUID, failParse: true}, http.StatusBadRequest, "", errorMessage("TEST failing to DECODE")},
-		{"UUIDMisMatch", newRequest("PUT", fmt.Sprintf("/dummies/%s", "99999")), mockConceptService{uuid: knownUUID}, http.StatusBadRequest, "", errorMessage("Uuids from payload and request, respectively, do not match: '12345' '99999'")},
-		{"WriteFailed", newRequest("PUT", fmt.Sprintf("/dummies/%s", knownUUID)), mockConceptService{uuid: knownUUID, failWrite: true}, http.StatusServiceUnavailable, "", errorMessage("TEST failing to WRITE")},
-		{"WriteFailedDueToConflict", newRequest("PUT", fmt.Sprintf("/dummies/%s", knownUUID)), mockConceptService{uuid: knownUUID, failConflict: true}, http.StatusConflict, "", errorMessage("")},
+		{"Success", newRequest("PUT", fmt.Sprintf("/dummies/%s", knownUUID)), &mockConceptService{uuid: knownUUID}, http.StatusOK, "", "{\"updatedIDs\":null}"},
+		{"ParseError", newRequest("PUT", fmt.Sprintf("/dummies/%s", knownUUID)), &mockConceptService{uuid: knownUUID, failParse: true}, http.StatusBadRequest, "", errorMessage("TEST failing to DECODE")},
+		{"UUIDMisMatch", newRequest("PUT", fmt.Sprintf("/dummies/%s", "99999")), &mockConceptService{uuid: knownUUID}, http.StatusBadRequest, "", errorMessage("Uuids from payload and request, respectively, do not match: '12345' '99999'")},
+		{"WriteFailed", newRequest("PUT", fmt.Sprintf("/dummies/%s", knownUUID)), &mockConceptService{uuid: knownUUID, failWrite: true}, http.StatusServiceUnavailable, "", errorMessage("TEST failing to WRITE")},
+		{"WriteFailedDueToConflict", newRequest("PUT", fmt.Sprintf("/dummies/%s", knownUUID)), &mockConceptService{uuid: knownUUID, failConflict: true}, http.StatusConflict, "", errorMessage("")},
 	}
 
 	for _, test := range tests {
@@ -54,9 +54,9 @@ func TestGetHandler(t *testing.T) {
 		contentType string // Contents of the Content-Type header
 		body        string
 	}{
-		{"Success", newRequest("GET", fmt.Sprintf("/dummies/%s", knownUUID)), mockConceptService{uuid: knownUUID}, http.StatusOK, "", "{}\n"},
-		{"NotFound", newRequest("GET", fmt.Sprintf("/dummies/%s", "99999")), mockConceptService{uuid: knownUUID}, http.StatusNotFound, "", "{\"message\":\"Concept with prefUUID 99999 not found in db.\"}"},
-		{"ReadError", newRequest("GET", fmt.Sprintf("/dummies/%s", knownUUID)), mockConceptService{uuid: knownUUID, failRead: true}, http.StatusServiceUnavailable, "", errorMessage("TEST failing to READ")},
+		{"Success", newRequest("GET", fmt.Sprintf("/dummies/%s", knownUUID)), &mockConceptService{uuid: knownUUID}, http.StatusOK, "", "{}\n"},
+		{"NotFound", newRequest("GET", fmt.Sprintf("/dummies/%s", "99999")), &mockConceptService{uuid: knownUUID}, http.StatusNotFound, "", "{\"message\":\"Concept with prefUUID 99999 not found in db.\"}"},
+		{"ReadError", newRequest("GET", fmt.Sprintf("/dummies/%s", knownUUID)), &mockConceptService{uuid: knownUUID, failRead: true}, http.StatusServiceUnavailable, "", errorMessage("TEST failing to READ")},
 	}
 
 	for _, test := range tests {
@@ -80,8 +80,8 @@ func TestGtgHandler(t *testing.T) {
 		contentType string // Contents of the Content-Type header
 		body        string
 	}{
-		{"Success", newRequest("GET", "/__gtg"), mockConceptService{failCheck: false}, http.StatusOK, "", "OK"},
-		{"GTGError", newRequest("GET", "/__gtg"), mockConceptService{failCheck: true}, http.StatusServiceUnavailable, "", "TEST failing to CHECK"},
+		{"Success", newRequest("GET", "/__gtg"), &mockConceptService{failCheck: false}, http.StatusOK, "", "OK"},
+		{"GTGError", newRequest("GET", "/__gtg"), &mockConceptService{failCheck: true}, http.StatusServiceUnavailable, "", "TEST failing to CHECK"},
 	}
 
 	for _, test := range tests {
@@ -110,13 +110,11 @@ func errorMessage(errMsg string) string {
 type mockConceptService struct {
 	mock.Mock
 	uuid         string
-	transId      string
+	transID      string
 	uuidList     []string
 	failParse    bool
 	failWrite    bool
 	failRead     bool
-	failDelete   bool
-	failCount    bool
 	failConflict bool
 	failCheck    bool
 }
@@ -124,7 +122,7 @@ type mockConceptService struct {
 type mockServiceData struct {
 }
 
-func (dS mockConceptService) Write(thing interface{}, transId string) (interface{}, error) {
+func (dS *mockConceptService) Write(thing interface{}, transID string) (interface{}, error) {
 	mockList := UpdatedConcepts{}
 	if dS.failWrite {
 		return mockList, errors.New("TEST failing to WRITE")
@@ -135,35 +133,35 @@ func (dS mockConceptService) Write(thing interface{}, transId string) (interface
 	if len(dS.uuidList) > 0 {
 		mockList.UpdatedIds = dS.uuidList
 	}
-	dS.transId = transId
+	dS.transID = transID
 	return mockList, nil
 }
 
-func (dS mockConceptService) Read(uuid string, transId string) (thing interface{}, found bool, err error) {
+func (dS *mockConceptService) Read(uuid string, transID string) (thing interface{}, found bool, err error) {
 	if dS.failRead {
 		return nil, false, errors.New("TEST failing to READ")
 	}
 	if uuid == dS.uuid {
 		return mockServiceData{}, true, nil
 	}
-	dS.transId = transId
+	dS.transID = transID
 	return nil, false, nil
 }
 
-func (dS mockConceptService) DecodeJSON(*json.Decoder) (thing interface{}, identity string, err error) {
+func (dS *mockConceptService) DecodeJSON(*json.Decoder) (thing interface{}, identity string, err error) {
 	if dS.failParse {
 		return "", "", errors.New("TEST failing to DECODE")
 	}
 	return mockServiceData{}, dS.uuid, nil
 }
 
-func (dS mockConceptService) Check() error {
+func (dS *mockConceptService) Check() error {
 	if dS.failCheck {
 		return errors.New("TEST failing to CHECK")
 	}
 	return nil
 }
 
-func (dS mockConceptService) Initialise() error {
+func (dS *mockConceptService) Initialise() error {
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 		conceptsService := concepts.NewConceptService(db)
 		conceptsService.Initialise()
 
-		handler := concepts.ConceptsHandler{ConceptsService: conceptsService}
+		handler := concepts.ConceptsHandler{ConceptsService: &conceptsService}
 
 		services := map[string]concepts.ConceptService{}
 		for _, path := range concepts.ConceptTypePaths {


### PR DESCRIPTION
The significant change is line 540 of concepts/concept_service.go - making sure relationships are removed when the node is deleted. (https://github.com/Financial-Times/concepts-rw-neo4j/commit/7d7d411656ed08c20ddd2ce389489fa604767f9b)

In addition, multiple writeHeader calls were being made after the JSON body was being encoded and written, causing a warning. (https://github.com/Financial-Times/concepts-rw-neo4j/pull/22/commits/3f1f694b3fbc56fd18add6ae077637c390bf4897)