### PR TITLE
Concord a canonical having multiple sources to another canonical concept

### DIFF
--- a/concepts/concepts_service.go
+++ b/concepts/concepts_service.go
@@ -1109,10 +1109,12 @@ func (s *ConceptService) writeCanonicalNodeForUnconcordedConcepts(concept Concep
 	allProps := setProps(concept, concept.UUID, false)
 	logger.WithField("UUID", concept.UUID).Debug("Creating prefUUID node for unconcorded concept")
 	createCanonicalNodeQuery := &neoism.CypherQuery{
-		Statement: fmt.Sprintf(`	MATCH (t:Thing{uuid:{prefUUID}})
-										MERGE (n:Thing {prefUUID: {prefUUID}})<-[:EQUIVALENT_TO]-(t)
-										set n={allprops}
-										set n :%s`, getAllLabels(concept.Type)),
+		Statement: fmt.Sprintf(`
+					MATCH (t:Thing{uuid:{prefUUID}})
+					MERGE (n:Thing {prefUUID: {prefUUID}})
+					MERGE (n)<-[:EQUIVALENT_TO]-(t)
+					set n={allprops}
+					set n :%s`, getAllLabels(concept.Type)),
 		Parameters: map[string]interface{}{
 			"prefUUID": concept.UUID,
 			"allprops": allProps,

--- a/concepts/concepts_service.go
+++ b/concepts/concepts_service.go
@@ -740,6 +740,7 @@ func (s *ConceptService) handleTransferConcordance(conceptData map[string]string
 				if updatedSourceID != newAggregatedConcept.PrefUUID {
 					authority := getCanonicalAuthority(newAggregatedConcept)
 					if result[0].Authority != authority && stringInArr(result[0].Authority, concordancesSources) {
+						logger.WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).Debugf("Canonical node for main source %s will need to be deleted and all concordances will be transfered to the new concordance", updatedSourceID)
 						// just delete the lone prefUUID node because the other concordances to
 						// this node should already be in the new sourceRepresentations (aggregate-concept-transformer responsability)
 						deleteLonePrefUUIDQueries = append(deleteLonePrefUUIDQueries, deleteLonePrefUUID(result[0].PrefUUID))

--- a/concepts/concepts_service.go
+++ b/concepts/concepts_service.go
@@ -701,21 +701,22 @@ func (s *ConceptService) handleTransferConcordance(conceptData map[string]string
 			return deleteLonePrefUUIDQueries, err
 		}
 
-		conceptType, err := mapper.MostSpecificType(result[0].Types)
+		queryResultedEntity := result[0]
+		conceptType, err := mapper.MostSpecificType(queryResultedEntity.Types)
 		if err != nil {
-			logger.WithError(err).WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).Errorf("could not return most specific type from source node: %v", result[0].Types)
+			logger.WithError(err).WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).Errorf("could not return most specific type from source node: %v", queryResultedEntity.Types)
 			return deleteLonePrefUUIDQueries, err
 		}
 
-		logger.WithField("UUID", updatedSourceID).Debug("Existing prefUUID is " + result[0].PrefUUID + " equivalence count is " + strconv.Itoa(result[0].Equivalence))
-		if result[0].Equivalence == 0 {
+		logger.WithField("UUID", updatedSourceID).Debug("Existing prefUUID is " + queryResultedEntity.PrefUUID + " equivalence count is " + strconv.Itoa(queryResultedEntity.Equivalence))
+		if queryResultedEntity.Equivalence == 0 {
 			// Source is old as exists in Neo4j without a prefNode. It can be transferred without issue
 			continue
-		} else if result[0].Equivalence == 1 {
+		} else if queryResultedEntity.Equivalence == 1 {
 			// Source exists in neo4j but is not concorded. It can be transferred without issue but its prefNode should be deleted
-			if updatedSourceID == result[0].PrefUUID {
+			if updatedSourceID == queryResultedEntity.PrefUUID {
 				logger.WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).Debugf("Pref uuid node for source %s will need to be deleted as its source will be removed", updatedSourceID)
-				deleteLonePrefUUIDQueries = append(deleteLonePrefUUIDQueries, deleteLonePrefUUID(result[0].PrefUUID))
+				deleteLonePrefUUIDQueries = append(deleteLonePrefUUIDQueries, deleteLonePrefUUID(queryResultedEntity.PrefUUID))
 				//concordance added
 				updateRecord.ChangedRecords = append(updateRecord.ChangedRecords, Event{
 					ConceptType:   conceptType,
@@ -731,19 +732,19 @@ func (s *ConceptService) handleTransferConcordance(conceptData map[string]string
 				continue
 			} else {
 				// Source is only source concorded to non-matching prefUUID; scenario should NEVER happen
-				err := fmt.Errorf("This source id: %s the only concordance to a non-matching node with prefUuid: %s", updatedSourceID, result[0].PrefUUID)
+				err := fmt.Errorf("This source id: %s the only concordance to a non-matching node with prefUuid: %s", updatedSourceID, queryResultedEntity.PrefUUID)
 				logger.WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).WithField("alert_tag", "ConceptLoadingDodgyData").Error(err)
 				return deleteLonePrefUUIDQueries, err
 			}
 		} else {
-			if updatedSourceID == result[0].PrefUUID {
+			if updatedSourceID == queryResultedEntity.PrefUUID {
 				if updatedSourceID != newAggregatedConcept.PrefUUID {
 					authority := getCanonicalAuthority(newAggregatedConcept)
-					if result[0].Authority != authority && stringInArr(result[0].Authority, concordancesSources) {
+					if queryResultedEntity.Authority != authority && stringInArr(queryResultedEntity.Authority, concordancesSources) {
 						logger.WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).Debugf("Canonical node for main source %s will need to be deleted and all concordances will be transfered to the new concordance", updatedSourceID)
 						// just delete the lone prefUUID node because the other concordances to
 						// this node should already be in the new sourceRepresentations (aggregate-concept-transformer responsability)
-						deleteLonePrefUUIDQueries = append(deleteLonePrefUUIDQueries, deleteLonePrefUUID(result[0].PrefUUID))
+						deleteLonePrefUUIDQueries = append(deleteLonePrefUUIDQueries, deleteLonePrefUUID(queryResultedEntity.PrefUUID))
 						updateRecord.ChangedRecords = append(updateRecord.ChangedRecords, Event{
 							ConceptType:   conceptType,
 							ConceptUUID:   updatedSourceID,
@@ -764,7 +765,7 @@ func (s *ConceptService) handleTransferConcordance(conceptData map[string]string
 				}
 			} else {
 				// Source was concorded to different concordance. Data on existing concordance is now out of date
-				logger.WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).WithField("alert_tag", "ConceptLoadingStaleData").Infof("Need to re-ingest concordance record for prefUuid: %s as source: %s has been removed.", result[0].PrefUUID, updatedSourceID)
+				logger.WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).WithField("alert_tag", "ConceptLoadingStaleData").Infof("Need to re-ingest concordance record for prefUuid: %s as source: %s has been removed.", queryResultedEntity.PrefUUID, updatedSourceID)
 
 				updateRecord.ChangedRecords = append(updateRecord.ChangedRecords, Event{
 					ConceptType:   conceptType,
@@ -773,7 +774,7 @@ func (s *ConceptService) handleTransferConcordance(conceptData map[string]string
 					TransactionID: transID,
 					EventDetails: ConcordanceEvent{
 						Type:  RemovedEvent,
-						OldID: result[0].PrefUUID,
+						OldID: queryResultedEntity.PrefUUID,
 						NewID: updatedSourceID,
 					},
 				})

--- a/concepts/concepts_service.go
+++ b/concepts/concepts_service.go
@@ -23,6 +23,8 @@ const (
 	RemovedEvent = "CONCORDANCE_REMOVED"
 )
 
+var concordancesSources = []string{"ManagedLocation", "Smartlogic"}
+
 // ConceptService - CypherDriver - CypherDriver
 type ConceptService struct {
 	conn neoutils.NeoConnection
@@ -169,6 +171,7 @@ type equivalenceResult struct {
 	PrefUUID    string   `json:"prefUuid"`
 	Types       []string `json:"types"`
 	Equivalence int      `json:"count"`
+	Authority   string   `json:"authority"`
 }
 
 //Read - read service
@@ -441,7 +444,7 @@ func (s *ConceptService) Write(thing interface{}, transID string) (interface{}, 
 
 		//Handle scenarios for transferring source id from an existing concordance to this concordance
 		if len(conceptsToTransferConcordance) > 0 {
-			prefUUIDsToBeDeletedQueryBatch, err = s.handleTransferConcordance(conceptsToTransferConcordance, &updateRecord, hashAsString, aggregatedConceptToWrite.PrefUUID, transID)
+			prefUUIDsToBeDeletedQueryBatch, err = s.handleTransferConcordance(conceptsToTransferConcordance, &updateRecord, hashAsString, aggregatedConceptToWrite, transID)
 			if err != nil {
 				return updateRecord, err
 			}
@@ -487,7 +490,7 @@ func (s *ConceptService) Write(thing interface{}, transID string) (interface{}, 
 			conceptsToCheckForExistingConcordance = append(conceptsToCheckForExistingConcordance, sr.UUID)
 		}
 
-		prefUUIDsToBeDeletedQueryBatch, err = s.handleTransferConcordance(requestSourceData, &updateRecord, hashAsString, aggregatedConceptToWrite.PrefUUID, transID)
+		prefUUIDsToBeDeletedQueryBatch, err = s.handleTransferConcordance(requestSourceData, &updateRecord, hashAsString, aggregatedConceptToWrite, transID)
 		if err != nil {
 			return updateRecord, err
 		}
@@ -640,7 +643,7 @@ func filterIdsThatAreUniqueToFirstMap(firstMapConcepts map[string]string, second
 }
 
 //Handle new source nodes that have been added to current concordance
-func (s *ConceptService) handleTransferConcordance(conceptData map[string]string, updateRecord *ConceptChanges, aggregateHash string, prefUUID string, transID string) ([]*neoism.CypherQuery, error) {
+func (s *ConceptService) handleTransferConcordance(conceptData map[string]string, updateRecord *ConceptChanges, aggregateHash string, newAggregatedConcept AggregatedConcept, transID string) ([]*neoism.CypherQuery, error) {
 	var result []equivalenceResult
 	var deleteLonePrefUUIDQueries []*neoism.CypherQuery
 
@@ -650,7 +653,7 @@ func (s *ConceptService) handleTransferConcordance(conceptData map[string]string
 					MATCH (t:Thing {uuid:{id}})
 					OPTIONAL MATCH (t)-[:EQUIVALENT_TO]->(c)
 					OPTIONAL MATCH (c)<-[eq:EQUIVALENT_TO]-(x:Thing)
-					RETURN t.uuid as sourceUuid, labels(t) as types, c.prefUUID as prefUuid, COUNT(DISTINCT eq) as count`,
+					RETURN t.uuid as sourceUuid, labels(t) as types, c.prefUUID as prefUuid, t.authority as authority, COUNT(DISTINCT eq) as count`,
 			Parameters: map[string]interface{}{
 				"id": updatedSourceID,
 			},
@@ -658,14 +661,14 @@ func (s *ConceptService) handleTransferConcordance(conceptData map[string]string
 		}
 		err := s.conn.CypherBatch([]*neoism.CypherQuery{equivQuery})
 		if err != nil {
-			logger.WithError(err).WithTransactionID(transID).WithUUID(prefUUID).Error("Requests for source nodes canonical information resulted in error")
+			logger.WithError(err).WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).Error("Requests for source nodes canonical information resulted in error")
 			return deleteLonePrefUUIDQueries, err
 		}
 
 		//source node does not currently exist in neo4j, nothing to tidy up
 		if len(result) == 0 {
-			logger.WithTransactionID(transID).WithUUID(prefUUID).Info("No existing concordance record found")
-			if updatedSourceID != prefUUID {
+			logger.WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).Info("No existing concordance record found")
+			if updatedSourceID != newAggregatedConcept.PrefUUID {
 				//concept does not exist, need update event
 				updateRecord.ChangedRecords = append(updateRecord.ChangedRecords, Event{
 					ConceptType:   conceptData[updatedSourceID],
@@ -686,7 +689,7 @@ func (s *ConceptService) handleTransferConcordance(conceptData map[string]string
 					EventDetails: ConcordanceEvent{
 						Type:  AddedEvent,
 						OldID: updatedSourceID,
-						NewID: prefUUID,
+						NewID: newAggregatedConcept.PrefUUID,
 					},
 				})
 			}
@@ -694,13 +697,13 @@ func (s *ConceptService) handleTransferConcordance(conceptData map[string]string
 		} else if len(result) > 1 {
 			//this scenario should never happen
 			err = fmt.Errorf("Multiple source concepts found with matching uuid: %s", updatedSourceID)
-			logger.WithTransactionID(transID).WithUUID(prefUUID).Error(err.Error())
+			logger.WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).Error(err.Error())
 			return deleteLonePrefUUIDQueries, err
 		}
 
 		conceptType, err := mapper.MostSpecificType(result[0].Types)
 		if err != nil {
-			logger.WithError(err).WithTransactionID(transID).WithUUID(prefUUID).Errorf("could not return most specific type from source node: %v", result[0].Types)
+			logger.WithError(err).WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).Errorf("could not return most specific type from source node: %v", result[0].Types)
 			return deleteLonePrefUUIDQueries, err
 		}
 
@@ -711,7 +714,7 @@ func (s *ConceptService) handleTransferConcordance(conceptData map[string]string
 		} else if result[0].Equivalence == 1 {
 			// Source exists in neo4j but is not concorded. It can be transferred without issue but its prefNode should be deleted
 			if updatedSourceID == result[0].PrefUUID {
-				logger.WithTransactionID(transID).WithUUID(prefUUID).Debugf("Pref uuid node for source %s will need to be deleted as its source will be removed", updatedSourceID)
+				logger.WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).Debugf("Pref uuid node for source %s will need to be deleted as its source will be removed", updatedSourceID)
 				deleteLonePrefUUIDQueries = append(deleteLonePrefUUIDQueries, deleteLonePrefUUID(result[0].PrefUUID))
 				//concordance added
 				updateRecord.ChangedRecords = append(updateRecord.ChangedRecords, Event{
@@ -722,27 +725,45 @@ func (s *ConceptService) handleTransferConcordance(conceptData map[string]string
 					EventDetails: ConcordanceEvent{
 						Type:  AddedEvent,
 						OldID: updatedSourceID,
-						NewID: prefUUID,
+						NewID: newAggregatedConcept.PrefUUID,
 					},
 				})
 				continue
 			} else {
 				// Source is only source concorded to non-matching prefUUID; scenario should NEVER happen
 				err := fmt.Errorf("This source id: %s the only concordance to a non-matching node with prefUuid: %s", updatedSourceID, result[0].PrefUUID)
-				logger.WithTransactionID(transID).WithUUID(prefUUID).WithField("alert_tag", "ConceptLoadingDodgyData").Error(err)
+				logger.WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).WithField("alert_tag", "ConceptLoadingDodgyData").Error(err)
 				return deleteLonePrefUUIDQueries, err
 			}
 		} else {
 			if updatedSourceID == result[0].PrefUUID {
-				if updatedSourceID != prefUUID {
+				if updatedSourceID != newAggregatedConcept.PrefUUID {
+					authority := getCanonicalAuthority(newAggregatedConcept)
+					if result[0].Authority != authority && stringInArr(result[0].Authority, concordancesSources) {
+						// just delete the lone prefUUID node because the other concordances to
+						// this node should already be in the new sourceRepresentations (aggregate-concept-transformer responsability)
+						deleteLonePrefUUIDQueries = append(deleteLonePrefUUIDQueries, deleteLonePrefUUID(result[0].PrefUUID))
+						updateRecord.ChangedRecords = append(updateRecord.ChangedRecords, Event{
+							ConceptType:   conceptType,
+							ConceptUUID:   updatedSourceID,
+							AggregateHash: aggregateHash,
+							TransactionID: transID,
+							EventDetails: ConcordanceEvent{
+								Type:  AddedEvent,
+								OldID: updatedSourceID,
+								NewID: newAggregatedConcept.PrefUUID,
+							},
+						})
+						continue
+					}
 					// Source is prefUUID for a different concordance
 					err := fmt.Errorf("Cannot currently process this record as it will break an existing concordance with prefUuid: %s", updatedSourceID)
-					logger.WithTransactionID(transID).WithUUID(prefUUID).WithField("alert_tag", "ConceptLoadingInvalidConcordance").Error(err)
+					logger.WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).WithField("alert_tag", "ConceptLoadingInvalidConcordance").Error(err)
 					return deleteLonePrefUUIDQueries, err
 				}
 			} else {
 				// Source was concorded to different concordance. Data on existing concordance is now out of date
-				logger.WithTransactionID(transID).WithUUID(prefUUID).WithField("alert_tag", "ConceptLoadingStaleData").Infof("Need to re-ingest concordance record for prefUuid: %s as source: %s has been removed.", result[0].PrefUUID, updatedSourceID)
+				logger.WithTransactionID(transID).WithUUID(newAggregatedConcept.PrefUUID).WithField("alert_tag", "ConceptLoadingStaleData").Infof("Need to re-ingest concordance record for prefUuid: %s as source: %s has been removed.", result[0].PrefUUID, updatedSourceID)
 
 				updateRecord.ChangedRecords = append(updateRecord.ChangedRecords, Event{
 					ConceptType:   conceptType,
@@ -764,7 +785,7 @@ func (s *ConceptService) handleTransferConcordance(conceptData map[string]string
 					EventDetails: ConcordanceEvent{
 						Type:  AddedEvent,
 						OldID: updatedSourceID,
-						NewID: prefUUID,
+						NewID: newAggregatedConcept.PrefUUID,
 					},
 				})
 				continue
@@ -1414,4 +1435,22 @@ func cleanSourceProperties(c AggregatedConcept) AggregatedConcept {
 	}
 	c.SourceRepresentations = cleanSources
 	return c
+}
+
+func getCanonicalAuthority(aggregate AggregatedConcept) string {
+	for _, source := range aggregate.SourceRepresentations {
+		if source.UUID == aggregate.PrefUUID {
+			return source.Authority
+		}
+	}
+	return ""
+}
+
+func stringInArr(searchFor string, values []string) bool {
+	for _, val := range values {
+		if searchFor == val {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This work is part of the wider work related to concording ManagedLocation and Editorial concepts via another concept.
With these changes, we allow to concord a ManagedLocation concept to a Smartlogic one, even if the ManagedLocation one has more than one source.

The delete of the concordance is done as it was done till now, but the consistency is ensured by another notification that is sent from [concordances-rw-neo4j](https://github.com/Financial-Times/concordances-rw-neo4j/pull/17).