### PR TITLE
Add option for specifying the amout of time db tx should be retried

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Options:
       --requestLoggingOn   Whether to log requests or not (env $REQUEST_LOGGING_ON) (default true)
       --logLevel           Level of logging to be shown (debug, info, warn, error) (env $LOG_LEVEL) (default "info")
       --dbDriverLogLevel   Db's driver logging level (debug, info, warn, error) (env $DB_DRIVER_LOG_LEVEL) (default "warn")
+      --maxTxRetryTime     Maximum amount of time a to retry executing a transaction(in seconds) (env $MAX_TX_RETRY_TIME) (default 30)
 ```
 
 All arguments are optional, they default to a local Neo4j install on the default port (7474), application running on port 8080, batchSize of 1024.

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mitchellh/hashstructure v1.0.0
+	github.com/neo4j/neo4j-go-driver/v4 v4.3.3
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 	github.com/sirupsen/logrus v1.1.1 // indirect
 	github.com/stretchr/testify v1.6.1


### PR DESCRIPTION
# Description

Add option for specifying the amount of time transaction should be retried. This will be helpful in cases where the service is started before Neo4j because right now it will use the default value of 30s and if it fails to `Initialise` in that time it will exit.
This scenario occurs when we are using `concepts-rw-neo4j` in integration tests of other services.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
