### PR TITLE
Use appSystemCode instead of appName for dbDriverLog

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 	app := cli.App(serviceName, appDescription)
 	appSystemCode := app.String(cli.StringOpt{
 		Name:   "app-system-code",
-		Value:  "concept-rw-neo4j",
+		Value:  "concepts-rw-neo4j",
 		Desc:   "System Code of the application",
 		EnvVar: "APP_SYSTEM_CODE",
 	})
@@ -72,7 +72,7 @@ func main() {
 	})
 
 	log := logger.NewUPPLogger(*appSystemCode, *logLevel)
-	dbDriverLog := logger.NewUPPLogger(*appName+"-cmneo4j-driver", *dbDriverLogLevel)
+	dbDriverLog := logger.NewUPPLogger(*appSystemCode+"-cmneo4j-driver", *dbDriverLogLevel)
 	app.Action = func() {
 		driver, err := cmneo4j.NewDefaultDriver(*neoURL, dbDriverLog)
 		if err != nil {


### PR DESCRIPTION
# Description

When using appName the service_name field in the logs is "Concept Rw Neo4j-cmneo4j-driver", whereas with appSystemCode the field will be "concepts-rw-neo4j-cmneo4j-driver".

## Why

I think it's more consistent if we use the version in this PR

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [X] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
