### PR TITLE
Rework how we set properties to complex relationships 

### DIFF
--- a/concepts/testdata/concept-queries-country-of-naics-rels.golden
+++ b/concepts/testdata/concept-queries-country-of-naics-rels.golden
@@ -52,20 +52,10 @@ Paremeters: {
 Statement: 
 		MERGE (thing:Thing {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (thing)-[:HAS_INDUSTRY_CLASSIFICATION]->(other)
-	,
+		MERGE (thing)-[rel:HAS_INDUSTRY_CLASSIFICATION]->(other)
+		SET rel=$relProps,
 Paremeters: {
   "id": "38ee195d-ebdd-48a9-af4b-c8a322e7b04d",
-  "uuid": "b4ddd5a5-0b6c-4dc2-bb75-3eb40c1b05ed"
-}
-==============================================================================
-Statement: 
-			MATCH (t:Thing {uuid: $uuid})
-			MATCH (other:Thing {uuid: $otherUUID})
-			MATCH (t)-[rel:HAS_INDUSTRY_CLASSIFICATION]->(other)
-			set rel=$relProps,
-Paremeters: {
-  "otherUUID": "38ee195d-ebdd-48a9-af4b-c8a322e7b04d",
   "relProps": {
     "rank": 2
   },
@@ -75,7 +65,7 @@ Paremeters: {
 Statement: 
 		MERGE (thing:Thing {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (thing)-[:COUNTRY_OF_INCORPORATION]->(other)
+		MERGE (thing)-[rel:COUNTRY_OF_INCORPORATION]->(other)
 	,
 Paremeters: {
   "id": "3e2eb1c1-7ecd-4600-8cbb-c02ba53ced4b",
@@ -85,7 +75,7 @@ Paremeters: {
 Statement: 
 		MERGE (thing:Thing {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (thing)-[:COUNTRY_OF_OPERATIONS]->(other)
+		MERGE (thing)-[rel:COUNTRY_OF_OPERATIONS]->(other)
 	,
 Paremeters: {
   "id": "3e2eb1c1-7ecd-4600-8cbb-c02ba53ced4b",
@@ -95,7 +85,7 @@ Paremeters: {
 Statement: 
 		MERGE (thing:Thing {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (thing)-[:COUNTRY_OF_RISK]->(other)
+		MERGE (thing)-[rel:COUNTRY_OF_RISK]->(other)
 	,
 Paremeters: {
   "id": "3e2eb1c1-7ecd-4600-8cbb-c02ba53ced4b",
@@ -105,20 +95,10 @@ Paremeters: {
 Statement: 
 		MERGE (thing:Thing {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (thing)-[:HAS_INDUSTRY_CLASSIFICATION]->(other)
-	,
+		MERGE (thing)-[rel:HAS_INDUSTRY_CLASSIFICATION]->(other)
+		SET rel=$relProps,
 Paremeters: {
   "id": "49da878c-67ce-4343-9a09-a4a767e584a2",
-  "uuid": "b4ddd5a5-0b6c-4dc2-bb75-3eb40c1b05ed"
-}
-==============================================================================
-Statement: 
-			MATCH (t:Thing {uuid: $uuid})
-			MATCH (other:Thing {uuid: $otherUUID})
-			MATCH (t)-[rel:HAS_INDUSTRY_CLASSIFICATION]->(other)
-			set rel=$relProps,
-Paremeters: {
-  "otherUUID": "49da878c-67ce-4343-9a09-a4a767e584a2",
   "relProps": {
     "rank": 1
   },

--- a/concepts/testdata/concept-queries-has-broader-rel.golden
+++ b/concepts/testdata/concept-queries-has-broader-rel.golden
@@ -33,7 +33,7 @@ Paremeters: {
 Statement: 
 		MATCH (concept:Concept {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (concept)-[:HAS_BROADER]->(other)	
+		MERGE (concept)-[rel:HAS_BROADER]->(other)	
 	,
 Paremeters: {
   "id": "b5d7c6b5-db7d-4bce-9d6a-f62195571f92",
@@ -43,7 +43,7 @@ Paremeters: {
 Statement: 
 		MATCH (concept:Concept {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (concept)-[:HAS_BROADER]->(other)	
+		MERGE (concept)-[rel:HAS_BROADER]->(other)	
 	,
 Paremeters: {
   "id": "f7e3fe2d-7496-4d42-b19f-378094efd263",

--- a/concepts/testdata/concept-queries-has-focus-rel.golden
+++ b/concepts/testdata/concept-queries-has-focus-rel.golden
@@ -33,7 +33,7 @@ Paremeters: {
 Statement: 
 		MATCH (concept:Concept {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (concept)-[:HAS_FOCUS]->(other)	
+		MERGE (concept)-[rel:HAS_FOCUS]->(other)	
 	,
 Paremeters: {
   "id": "2e7429bd-7a84-41cb-a619-2c702893e359",
@@ -43,7 +43,7 @@ Paremeters: {
 Statement: 
 		MATCH (concept:Concept {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (concept)-[:HAS_FOCUS]->(other)	
+		MERGE (concept)-[rel:HAS_FOCUS]->(other)	
 	,
 Paremeters: {
   "id": "740c604b-8d97-443e-be70-33de6f1d6e67",
@@ -53,7 +53,7 @@ Paremeters: {
 Statement: 
 		MATCH (concept:Concept {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (concept)-[:HAS_FOCUS]->(other)	
+		MERGE (concept)-[rel:HAS_FOCUS]->(other)	
 	,
 Paremeters: {
   "id": "c28fa0b4-4245-11e8-842f-0ed5f89f718b",

--- a/concepts/testdata/concept-queries-has-parent-rel.golden
+++ b/concepts/testdata/concept-queries-has-parent-rel.golden
@@ -42,7 +42,7 @@ Paremeters: {
 Statement: 
 		MERGE (thing:Thing {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (thing)-[:HAS_PARENT]->(other)
+		MERGE (thing)-[rel:HAS_PARENT]->(other)
 	,
 Paremeters: {
   "id": "2ef39c2a-da9c-4263-8209-ebfd490d3101",

--- a/concepts/testdata/concept-queries-implied-by-rel.golden
+++ b/concepts/testdata/concept-queries-implied-by-rel.golden
@@ -33,7 +33,7 @@ Paremeters: {
 Statement: 
 		MATCH (concept:Concept {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (concept)-[:IMPLIED_BY]->(other)	
+		MERGE (concept)-[rel:IMPLIED_BY]->(other)	
 	,
 Paremeters: {
   "id": "740c604b-8d97-443e-be70-33de6f1d6e67",
@@ -43,7 +43,7 @@ Paremeters: {
 Statement: 
 		MATCH (concept:Concept {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (concept)-[:IMPLIED_BY]->(other)	
+		MERGE (concept)-[rel:IMPLIED_BY]->(other)	
 	,
 Paremeters: {
   "id": "b5d7c6b5-db7d-4bce-9d6a-f62195571f92",

--- a/concepts/testdata/concept-queries-is-related-to-rel.golden
+++ b/concepts/testdata/concept-queries-is-related-to-rel.golden
@@ -33,7 +33,7 @@ Paremeters: {
 Statement: 
 		MATCH (concept:Concept {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (concept)-[:IS_RELATED_TO]->(other)	
+		MERGE (concept)-[rel:IS_RELATED_TO]->(other)	
 	,
 Paremeters: {
   "id": "b5d7c6b5-db7d-4bce-9d6a-f62195571f92",
@@ -43,7 +43,7 @@ Paremeters: {
 Statement: 
 		MATCH (concept:Concept {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (concept)-[:IS_RELATED_TO]->(other)	
+		MERGE (concept)-[rel:IS_RELATED_TO]->(other)	
 	,
 Paremeters: {
   "id": "f7e3fe2d-7496-4d42-b19f-378094efd263",

--- a/concepts/testdata/concept-queries-membership-rels.golden
+++ b/concepts/testdata/concept-queries-membership-rels.golden
@@ -37,7 +37,7 @@ Paremeters: {
 Statement: 
 		MERGE (thing:Thing {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (thing)-[:HAS_MEMBER]->(other)
+		MERGE (thing)-[rel:HAS_MEMBER]->(other)
 	,
 Paremeters: {
   "id": "35946807-0205-4fc1-8516-bb1ae141659b",
@@ -47,7 +47,7 @@ Paremeters: {
 Statement: 
 		MERGE (thing:Thing {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (thing)-[:HAS_ORGANISATION]->(other)
+		MERGE (thing)-[rel:HAS_ORGANISATION]->(other)
 	,
 Paremeters: {
   "id": "7f40d291-b3cb-47c4-9bce-18413e9350cf",
@@ -57,20 +57,10 @@ Paremeters: {
 Statement: 
 		MERGE (thing:Thing {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (thing)-[:HAS_ROLE]->(other)
-	,
+		MERGE (thing)-[rel:HAS_ROLE]->(other)
+		SET rel=$relProps,
 Paremeters: {
   "id": "f807193d-337b-412f-b32c-afa14b385819",
-  "uuid": "cbadd9a7-5da9-407a-a5ec-e379460991f2"
-}
-==============================================================================
-Statement: 
-			MATCH (t:Thing {uuid: $uuid})
-			MATCH (other:Thing {uuid: $otherUUID})
-			MATCH (t)-[rel:HAS_ROLE]->(other)
-			set rel=$relProps,
-Paremeters: {
-  "otherUUID": "f807193d-337b-412f-b32c-afa14b385819",
   "relProps": {
     "inceptionDate": "2016-01-01",
     "inceptionDateEpoch": 1451606400,
@@ -83,20 +73,10 @@ Paremeters: {
 Statement: 
 		MERGE (thing:Thing {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (thing)-[:HAS_ROLE]->(other)
-	,
+		MERGE (thing)-[rel:HAS_ROLE]->(other)
+		SET rel=$relProps,
 Paremeters: {
   "id": "fe94adc6-ca44-438f-ad8f-0188d4a74987",
-  "uuid": "cbadd9a7-5da9-407a-a5ec-e379460991f2"
-}
-==============================================================================
-Statement: 
-			MATCH (t:Thing {uuid: $uuid})
-			MATCH (other:Thing {uuid: $otherUUID})
-			MATCH (t)-[rel:HAS_ROLE]->(other)
-			set rel=$relProps,
-Paremeters: {
-  "otherUUID": "fe94adc6-ca44-438f-ad8f-0188d4a74987",
   "relProps": {
     "inceptionDate": "1968-01-01",
     "terminationDate": "1968-01-01"

--- a/concepts/testdata/concept-queries-sub-organisation-of-rel.golden
+++ b/concepts/testdata/concept-queries-sub-organisation-of-rel.golden
@@ -55,7 +55,7 @@ Paremeters: {
 Statement: 
 		MERGE (thing:Thing {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (thing)-[:SUB_ORGANISATION_OF]->(other)
+		MERGE (thing)-[rel:SUB_ORGANISATION_OF]->(other)
 	,
 Paremeters: {
   "id": "c001ee9c-94c5-11e8-8f42-da24cd01f044",

--- a/concepts/testdata/concept-queries-superseded-by-rel.golden
+++ b/concepts/testdata/concept-queries-superseded-by-rel.golden
@@ -33,7 +33,7 @@ Paremeters: {
 Statement: 
 		MATCH (concept:Concept {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (concept)-[:SUPERSEDED_BY]->(other)	
+		MERGE (concept)-[rel:SUPERSEDED_BY]->(other)	
 	,
 Paremeters: {
   "id": "1a96ee7a-a4af-3a56-852c-60420b0b8da6",
@@ -43,7 +43,7 @@ Paremeters: {
 Statement: 
 		MATCH (concept:Concept {uuid: $uuid})
 		MERGE (other:Thing {uuid: $id})
-		MERGE (concept)-[:SUPERSEDED_BY]->(other)	
+		MERGE (concept)-[rel:SUPERSEDED_BY]->(other)	
 	,
 Paremeters: {
   "id": "b5d7c6b5-db7d-4bce-9d6a-f62195571f92",

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -14,7 +14,7 @@ services:
     depends_on:
       - neo4j
   neo4j:
-    image: neo4j:3.5.28-enterprise
+    image: neo4j:4.3-enterprise
     environment:
           NEO4J_AUTH: none
           NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"


### PR DESCRIPTION
# Description

## What

Rework how we setup relationship properties. Instead of using two separate Neo4j queries, now we use a single one that both creates the relationship and sets its properties.

## Why

With the old approach we experienced critical failure when writing a lot of Membership Concepts. Somehow when using separate queries the service was able to deadlock itself, waiting to write relationships. It is still unclear to me what exactly was happening, as query batches are executed in the same transaction.
The new way seems to resolve the issue.

## Anything, in particular, you'd like to highlight to reviewers

To test the fix you can "force" factset concept carousel to ingest the membership table and monitor the service.
- Scale down `factset-concept-carousel`.
- In the `factset` RDS, in `carousel_status_upp_staging_publish_eu` table, set `current_table: ppl_v1_ppl_jobs` and `current_position: 0`, `bucket_count:0`
- Scale up `factset-concept-carousel`.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
