### PR TITLE
UPPSF-3082 Implemented a DELETE endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ If not found, you'll get a 404 response.
 Empty fields are omitted from the response.
 `curl -H "X-Request-Id: 123" localhost:8080/sections/3fa70485-3a57-3b9b-9449-774b001cd965`
 
+### DELETE /{taxonomy}/{uuid}
+Deletes a canonical concept and its concorded source concepts but only if they do not have any incoming relationships, e.g.
+no content is annotated with any of the source concepts, no relationships to other concepts.
+
+If not found, you'll get a 404 response. If the concept cannot be deleted, you'll get 400 with a response containing the reason.
+
+`curl -XDELETE -H "X-Request-Id: 123" localhost:8080/sections/3fa70485-3a57-3b9b-9449-774b001cd965`
+
 ### Admin endpoints
 Healthchecks: [http://localhost:8080/__health](http://localhost:8080/__health)
 Good to Go: [http://localhost:8080/__gtg](http://localhost:8080/__gtg)

--- a/concepts/concept_service_mock.go
+++ b/concepts/concept_service_mock.go
@@ -8,16 +8,16 @@ import (
 type mockConceptService struct {
 	write      func(thing interface{}, transID string) (interface{}, error)
 	read       func(uuid string, transID string) (interface{}, bool, error)
-	delete     func(uuid string, transID string) error
+	delete     func(uuid string, transID string) ([]string, error)
 	decodeJSON func(*json.Decoder) (interface{}, string, error)
 	check      func() error
 }
 
-func (mcs *mockConceptService) Delete(uuid string, transID string) error {
+func (mcs *mockConceptService) Delete(uuid string, transID string) ([]string, error) {
 	if mcs.delete != nil {
 		return mcs.delete(uuid, transID)
 	}
-	return errors.New("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (mcs *mockConceptService) Write(thing interface{}, transID string) (interface{}, error) {

--- a/concepts/concept_service_mock.go
+++ b/concepts/concept_service_mock.go
@@ -8,8 +8,16 @@ import (
 type mockConceptService struct {
 	write      func(thing interface{}, transID string) (interface{}, error)
 	read       func(uuid string, transID string) (interface{}, bool, error)
+	delete     func(uuid string, transID string) error
 	decodeJSON func(*json.Decoder) (interface{}, string, error)
 	check      func() error
+}
+
+func (mcs *mockConceptService) Delete(uuid string, transID string) error {
+	if mcs.delete != nil {
+		return mcs.delete(uuid, transID)
+	}
+	return errors.New("not implemented")
 }
 
 func (mcs *mockConceptService) Write(thing interface{}, transID string) (interface{}, error) {

--- a/concepts/concepts_service_test.go
+++ b/concepts/concepts_service_test.go
@@ -2356,6 +2356,114 @@ func TestWriteLocation(t *testing.T) {
 	readConceptAndCompare(t, locationISO31661, "TestWriteLocationISO31661")
 }
 
+//nolint:gocognit
+func TestConceptService_Delete(t *testing.T) {
+	tests := []struct {
+		testName             string
+		aggregatedConcept    transform.OldAggregatedConcept
+		otherRelatedConcepts []transform.OldAggregatedConcept
+		expectedErr          error
+		deleteUUIDs          []string
+	}{
+		{
+			testName:          "Deletes a canonical concept with a single source",
+			aggregatedConcept: getAggregatedConcept(t, "single-concordance.json"),
+			deleteUUIDs:       []string{basicConceptUUID},
+		},
+		{
+			testName:          "Deletes a concept which has outgoing relationship",
+			aggregatedConcept: getAggregatedConcept(t, "concept-with-multiple-related-to.json"),
+			deleteUUIDs:       []string{basicConceptUUID},
+		},
+		{
+			testName:          "Throws an error when deleting a source concept different from the canonical",
+			aggregatedConcept: getAggregatedConcept(t, "tri-concordance.json"),
+			expectedErr:       ErrDeleteSource,
+			deleteUUIDs:       []string{sourceID1},
+		},
+		{
+			testName:          "Throws an error when deleting a concept that has relations",
+			aggregatedConcept: getAggregatedConcept(t, "concept-with-multiple-related-to.json"),
+			otherRelatedConcepts: []transform.OldAggregatedConcept{
+				getAggregatedConcept(t, "yet-another-full-lone-aggregated-concept.json"),
+			},
+			expectedErr: ErrDeleteRelated,
+			deleteUUIDs: []string{yetAnotherBasicConceptUUID},
+		},
+		{
+			testName:          "Throws an error when deleting a concept with concordances which have relations to other things",
+			aggregatedConcept: getAggregatedConcept(t, "concept-with-related-to.json"),
+			otherRelatedConcepts: []transform.OldAggregatedConcept{
+				getAggregatedConcept(t, "transfer-multiple-source-concordance.json"),
+			},
+			expectedErr: ErrDeleteRelated,
+			deleteUUIDs: []string{simpleSmartlogicTopicUUID},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			defer cleanDB(t)
+
+			// Create the related, broader than and impliedBy on concepts
+			for _, relatedConcept := range test.otherRelatedConcepts {
+				_, err := conceptsDriver.Write(relatedConcept, "")
+				if !assert.NoError(t, err, "Failed to write related/broader/impliedBy concept") {
+					return
+				}
+			}
+			_, err := conceptsDriver.Write(test.aggregatedConcept, "")
+			assert.Nil(t, err)
+
+			// Attempt to delete the chosen UUIDs.
+			for _, uuid := range test.deleteUUIDs {
+				err = conceptsDriver.Delete(uuid, "")
+				if test.expectedErr != nil {
+					assert.Equal(t, test.expectedErr, err)
+				} else {
+					assert.Nil(t, err)
+				}
+			}
+
+			// Check if the deletion was actually successful if this was expected
+			if test.expectedErr == nil {
+				for _, uuid := range test.deleteUUIDs {
+					query := &cmneo4j.Query{
+						Cypher: "MATCH (n:Concept{uuid:$uuid}) RETURN n",
+						Params: map[string]interface{}{"uuid": uuid},
+						Result: &struct{}{},
+					}
+					err := conceptsDriver.driver.Read(query)
+					assert.ErrorIs(t, err, cmneo4j.ErrNoResultsFound, "UUID: %s", uuid)
+				}
+			}
+		})
+	}
+}
+
+func TestConceptService_DeleteConcordedCanonical(t *testing.T) {
+	defer cleanDB(t)
+
+	aggregatedConcept := getAggregatedConcept(t, "tri-concordance.json")
+	_, err := conceptsDriver.Write(aggregatedConcept, "")
+	assert.Nil(t, err)
+
+	err = conceptsDriver.Delete(aggregatedConcept.PrefUUID, "")
+	assert.Nil(t, err)
+
+	// All source representations should be deleted also
+	for _, c := range aggregatedConcept.SourceRepresentations {
+		err := conceptsDriver.driver.Read(&cmneo4j.Query{
+			Cypher: "MATCH (n:Concept{uuid:$uuid}) RETURN n",
+			Params: map[string]interface{}{
+				"uuid": c.UUID,
+			},
+			Result: &struct{}{},
+		})
+		assert.ErrorIs(t, err, cmneo4j.ErrNoResultsFound, "UUID: %s", c.UUID)
+	}
+}
+
 func readConceptAndCompare(t *testing.T, payload transform.OldAggregatedConcept, testName string, ignoredFields ...string) {
 	actualIf, found, err := conceptsDriver.Read(payload.PrefUUID, "")
 	actual := actualIf.(transform.OldAggregatedConcept)


### PR DESCRIPTION
# Description
This PR implements a `DELETE /<concept-type>/<uuid>` endpoint that can be used to delete an unused canonical concept which also deletes all concorded source concepts.

## What
Before deleting a concept the following checks are made on the concept:
 - exists and the request path contains the correct concept-type. This is done in the HTTP handler.
 - is a canonical concept and not a source concept
 - the concept and all concorded concepts do not have any incoming relationships (e.g. no content is annotated with them, no other concepts refer to them)

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-3082)

## Anything, in particular, you'd like to highlight to reviewers

 - [The Cypher query that deletes the concepts](https://github.com/Financial-Times/concepts-rw-neo4j/pull/99/files#diff-7c5458201a51f6224ce5f6096af5dce24c5bf67b6ea0baa92591207fe015f357R406) does not use `DETACH DELETE` but explicitly deletes relationships and nodes. This is to avoid the possibility of having an orphaned concept if the above checks do not cover an edge case.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [x] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
