### PR TITLE
Update cm-graph-ontology lib to v0.0.4

### DIFF
--- a/concepts/concepts_service.go
+++ b/concepts/concepts_service.go
@@ -688,15 +688,19 @@ func cleanSourceProperties(c ontology.NewAggregatedConcept) ontology.NewAggregat
 	var cleanSources []ontology.NewConcept
 	for _, source := range c.SourceRepresentations {
 		cleanConcept := ontology.NewConcept{
-			Relationships:  source.Relationships,
-			UUID:           source.UUID,
-			PrefLabel:      source.PrefLabel,
-			Type:           source.Type,
-			Authority:      source.Authority,
-			AuthorityValue: source.AuthorityValue,
-			IssuedBy:       source.IssuedBy,
-			FigiCode:       source.FigiCode,
-			IsDeprecated:   source.IsDeprecated,
+			SourceConceptFields: ontology.SourceConceptFields{
+				UUID:           source.UUID,
+				Type:           source.Type,
+				PrefLabel:      source.PrefLabel,
+				Authority:      source.Authority,
+				AuthorityValue: source.AuthorityValue,
+				FigiCode:       source.FigiCode,
+				IssuedBy:       source.IssuedBy,
+				IsDeprecated:   source.IsDeprecated,
+			},
+			DynamicFields: ontology.DynamicFields{
+				Relationships: source.Relationships,
+			},
 		}
 		cleanSources = append(cleanSources, cleanConcept)
 	}

--- a/concepts/testdata/organisation-with-naics-unknown.json
+++ b/concepts/testdata/organisation-with-naics-unknown.json
@@ -21,12 +21,6 @@
   "properName": "The New York Times Co.",
   "shortName": "The New York Times",
   "yearFounded": 1851,
-  "naicsIndustryClassifications": [
-    {
-      "uuid": "07fb6996-f046-4e95-8aaf-fafd138ca3ec",
-      "rank": 1
-    }
-  ],
   "sourceRepresentations": [
     {
       "uuid": "b4ddd5a5-0b6c-4dc2-bb75-3eb40c1b05ed",

--- a/concepts/testdata/organisation-with-naics.json
+++ b/concepts/testdata/organisation-with-naics.json
@@ -21,16 +21,6 @@
   "properName": "The New York Times Co.",
   "shortName": "The New York Times",
   "yearFounded": 1851,
-  "naicsIndustryClassifications": [
-    {
-      "uuid": "49da878c-67ce-4343-9a09-a4a767e584a2",
-      "rank": 1
-    },
-    {
-      "uuid": "38ee195d-ebdd-48a9-af4b-c8a322e7b04d",
-      "rank": 2
-    }
-  ],
   "sourceRepresentations": [
     {
       "uuid": "b4ddd5a5-0b6c-4dc2-bb75-3eb40c1b05ed",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Financial-Times/concepts-rw-neo4j
 go 1.16
 
 require (
-	github.com/Financial-Times/cm-graph-ontology v0.0.1
+	github.com/Financial-Times/cm-graph-ontology v0.0.4
 	github.com/Financial-Times/cm-neo4j-driver v1.1.0
 	github.com/Financial-Times/go-fthealth v0.0.0-20171204124831-1b007e2b37b7
 	github.com/Financial-Times/go-logger/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Financial-Times/cm-graph-ontology v0.0.1 h1:11J8a0+QOe1SfbCnDvLQT2R75qUz4XmGQuOGQbDJt4A=
 github.com/Financial-Times/cm-graph-ontology v0.0.1/go.mod h1:h/8ojXW//7avrChq3Tk+TcHpNmBhL59YQMvS8T0tvd4=
+github.com/Financial-Times/cm-graph-ontology v0.0.4 h1:0MYFhCQH8qV+Qla4aSePr81JlI5Dy4IymH/ZxcqEbzQ=
+github.com/Financial-Times/cm-graph-ontology v0.0.4/go.mod h1:oZOHP4/83o8jExjKMqTSDajC4WXBJ0qK5wZfwu/+l+g=
 github.com/Financial-Times/cm-neo4j-driver v1.1.0 h1:9TZgyE7Vl8iuH0MRQlrVLkjzLFwIQsCn/td806WU7A8=
 github.com/Financial-Times/cm-neo4j-driver v1.1.0/go.mod h1:fQ77C8A+6I+ihwe6Ob8Y7sIzU3s/DTrjBZJGVQOeum0=
 github.com/Financial-Times/go-fthealth v0.0.0-20171204124831-1b007e2b37b7 h1:dkf1EOTiHXA2lG2EJuePEim6y0HEOPt0hcqsT/qUr/k=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/Financial-Times/cm-graph-ontology v0.0.1 h1:11J8a0+QOe1SfbCnDvLQT2R75qUz4XmGQuOGQbDJt4A=
-github.com/Financial-Times/cm-graph-ontology v0.0.1/go.mod h1:h/8ojXW//7avrChq3Tk+TcHpNmBhL59YQMvS8T0tvd4=
 github.com/Financial-Times/cm-graph-ontology v0.0.4 h1:0MYFhCQH8qV+Qla4aSePr81JlI5Dy4IymH/ZxcqEbzQ=
 github.com/Financial-Times/cm-graph-ontology v0.0.4/go.mod h1:oZOHP4/83o8jExjKMqTSDajC4WXBJ0qK5wZfwu/+l+g=
 github.com/Financial-Times/cm-neo4j-driver v1.1.0 h1:9TZgyE7Vl8iuH0MRQlrVLkjzLFwIQsCn/td806WU7A8=


### PR DESCRIPTION
# Description

## What

Update the service to use the latest cm-graph-ontology version

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3244

## Anything, in particular, you'd like to highlight to reviewers

It is safe to delete the naics field from the aggregate concept fixture. This is because it was never read or serialised by the concepts-rw-neo4j service. It was removed because with the new ontology lib setup the tests started failing when comparing what was written vs what was read.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
