### PR TITLE
fix sporadically failing test

### DIFF
--- a/concepts/concepts_service_test.go
+++ b/concepts/concepts_service_test.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1245,7 +1244,7 @@ func TestWriteMemberships_FixOldData(t *testing.T) {
 	}
 
 	assert.Equal(t, memRoles, 2)
-	assert.True(t, reflect.DeepEqual(ontology.Relationships{anotherMembershipRole, membershipRole}, updatedRelationships))
+	assert.True(t, cmp.Equal(ontology.Relationships{anotherMembershipRole, membershipRole}, updatedRelationships, cmpopts.SortMaps(func(a, b string) bool { return a < b })))
 	assert.Equal(t, organisationUUID, extractFieldFromRelationship(originalMembership.Relationships, "HAS_ORGANISATION"))
 	assert.Equal(t, personUUID, extractFieldFromRelationship(originalMembership.Relationships, "HAS_MEMBER"))
 }

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -10,7 +10,7 @@ services:
     container_name: test-runner
     environment:
       - NEO4J_TEST_URL=bolt://neo4j:7687
-    command: ["go", "test", "-mod=readonly", "-race", "-tags=integration", "./..."]
+    command: ["go", "test", "-v", "-mod=readonly", "-race", "-tags=integration", "./..."]
     depends_on:
       - neo4j
   neo4j:


### PR DESCRIPTION
# Description

## What

One the previous merge one of the integration tests failed because we were comparing a map of interfaces. As we know in Go the order of the map is not guaranteed resulting in sporadic test failures. To avoid this issue now we are using the cmp library which is flattening the map to a type that can be sorted by providing a sorting function.

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
